### PR TITLE
Fix: Assign block tracking IDs via an atomic counter

### DIFF
--- a/lib/SpoorTrackingModule.js
+++ b/lib/SpoorTrackingModule.js
@@ -1,4 +1,5 @@
 import { AbstractModule } from 'adapt-authoring-core'
+import { parseObjectId } from 'adapt-authoring-mongodb'
 import { loadRouteConfig, registerRoutes } from 'adapt-authoring-server'
 /**
  * Module for making course content compatible with spoor
@@ -8,8 +9,13 @@ import { loadRouteConfig, registerRoutes } from 'adapt-authoring-server'
 class SpoorTrackingModule extends AbstractModule {
   /** @override */
   async init () {
-    const [auth, content, server] = await this.app.waitForModule('auth', 'content', 'server')
+    const [auth, content, mongodb, server] = await this.app.waitForModule('auth', 'content', 'mongodb', 'server')
 
+    /** @ignore */ this.content = content
+    /** @ignore */ this.mongodb = mongodb
+
+    // Mint a tracking ID for every new block. preInsertHook also fires once per payload during a
+    // bulk clone, so this is the single place tracking IDs are assigned.
     content.preInsertHook.tap(this.insertTrackingId.bind(this))
 
     const config = await loadRouteConfig(this.rootDir, this)
@@ -18,27 +24,86 @@ class SpoorTrackingModule extends AbstractModule {
   }
 
   /**
-   * Adds the latest tracking ID to a block
-   * @param {Object} data The block data to update
+   * Collection holding the per-course tracking ID counters. Shared with the content module's
+   * friendly ID counters, so deleting a course removes both in content's existing sweep.
+   * @type {String}
    */
-  async insertTrackingId (data) {
-    if (data._type !== 'block' || Number.isInteger(data._trackingId)) {
-      return
-    }
-    const content = await this.app.waitForModule('content')
-    const [{ _trackingId } = {}] = await content.find({ _courseId: data._courseId }, {}, { limit: 1, sort: [['_trackingId', -1]] })
-    data._trackingId = (_trackingId ?? 0) + 1
+  get counterCollectionName () {
+    return this.content.counterCollectionName
   }
 
   /**
-   * Resets all tracking IDs for a single course
+   * Assigns a unique tracking ID to a newly inserted block. Language replicas created by the
+   * multilang module deliberately reuse the source block's ID, so those (flagged `_multilangSync`)
+   * inserts are left untouched.
+   * @param {Object} data The content being inserted
+   * @param {Object} options Insert options
+   * @return {Promise}
+   */
+  async insertTrackingId (data, options = {}) {
+    if (data._type !== 'block' || options._multilangSync) {
+      return
+    }
+    const [trackingId] = await this.allocateTrackingIds(data._courseId, 1)
+    data._trackingId = trackingId
+  }
+
+  /**
+   * Atomically reserves a contiguous range of unique tracking IDs for a course's blocks. The
+   * counter is advanced with a single findOneAndUpdate, so allocation never reads back through
+   * the cached content query that previously handed colliding IDs to rapid/concurrent inserts.
+   * @param {String} _courseId The course the blocks belong to
+   * @param {Number} count Number of IDs to reserve
+   * @return {Promise<Array<Number>>}
+   */
+  async allocateTrackingIds (_courseId, count = 1) {
+    if (count < 1) {
+      return []
+    }
+    const counters = this.mongodb.getCollection(this.counterCollectionName)
+    const query = { _type: '_trackingId', _courseId: parseObjectId(_courseId) }
+    // Seed from any existing blocks on first use (e.g. courses that predate this counter)
+    if (!await counters.findOne(query)) {
+      const maxTrackingId = await this.findMaxTrackingId(_courseId)
+      await counters.updateOne(query, { $setOnInsert: { seq: maxTrackingId } }, { upsert: true })
+    }
+    const counter = await counters.findOneAndUpdate(query, { $inc: { seq: count } }, { returnDocument: 'after' })
+    const startSeq = counter.seq - count + 1
+    return Array.from({ length: count }, (_, i) => startSeq + i)
+  }
+
+  /**
+   * Finds the highest tracking ID currently assigned to a course's blocks (used to seed the
+   * counter). Reads the DB directly to bypass the content cache.
+   * @param {String} _courseId The course _id
+   * @return {Promise<Number>}
+   */
+  async findMaxTrackingId (_courseId) {
+    const [block] = await this.mongodb.getCollection(this.content.collectionName)
+      .find({ _type: 'block', _courseId: parseObjectId(_courseId), _trackingId: { $type: 'number' } }, { projection: { _trackingId: 1 } })
+      .sort({ _trackingId: -1 })
+      .limit(1)
+      .toArray()
+    return block?._trackingId ?? 0
+  }
+
+  /**
+   * Resets all tracking IDs for a single course to a clean 1..n sequence and realigns the counter.
+   * This is the canonical way to renumber a course's tracking IDs — reuse it rather than
+   * reimplementing the renumbering elsewhere.
    * @param {String} _courseId The course _id
    * @return {Promise}
    */
   async resetCourseTrackingIds (_courseId) {
-    const content = await this.app.waitForModule('content')
-    const blocks = await content.find({ _type: 'block', _courseId }, {}, { sort: [['_trackingId', 1]] })
-    await Promise.all(blocks.map((b, i) => content.update({ _id: b._id }, { _trackingId: i + 1 }, { schemaName: 'block' })))
+    const collection = this.mongodb.getCollection(this.content.collectionName)
+    const blocks = await collection
+      .find({ _type: 'block', _courseId: parseObjectId(_courseId) }, { projection: { _id: 1 } })
+      .sort({ _trackingId: 1 })
+      .toArray()
+    await Promise.all(blocks.map((b, i) => collection.updateOne({ _id: b._id }, { $set: { _trackingId: i + 1 } })))
+    // Keep the allocation counter in step with the renumbering
+    await this.mongodb.getCollection(this.counterCollectionName)
+      .updateOne({ _type: '_trackingId', _courseId: parseObjectId(_courseId) }, { $set: { seq: blocks.length } }, { upsert: true })
     this.log('debug', 'RESET', _courseId)
   }
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "peerDependencies": {
     "adapt-authoring-auth": "^2.0.0",
     "adapt-authoring-content": "^3.0.0",
+    "adapt-authoring-mongodb": "^3.0.0",
     "adapt-authoring-server": "^2.0.0"
   },
   "peerDependenciesMeta": {
@@ -23,6 +24,9 @@
       "optional": true
     },
     "adapt-authoring-content": {
+      "optional": true
+    },
+    "adapt-authoring-mongodb": {
       "optional": true
     },
     "adapt-authoring-server": {

--- a/tests/SpoorTrackingModule.spec.js
+++ b/tests/SpoorTrackingModule.spec.js
@@ -3,46 +3,57 @@ import assert from 'node:assert/strict'
 
 import SpoorTrackingModule from '../lib/SpoorTrackingModule.js'
 
+// A valid 24-char hex string so parseObjectId() doesn't throw
+const COURSE_ID = '0123456789abcdef01234567'
+
 /**
- * Creates a mock SpoorTrackingModule instance with stubbed app dependencies.
- * Since SpoorTrackingModule extends AbstractModule and relies on a running
- * application, we construct a plain object with the module's prototype methods
- * and inject mock collaborators.
+ * Builds a chainable cursor mock for collection.find(...).sort(...).limit(...).toArray()
  */
-function createMockInstance (overrides = {}) {
+function makeCursor (docs) {
+  const cursor = {
+    sort: mock.fn(() => cursor),
+    limit: mock.fn(() => cursor),
+    toArray: mock.fn(async () => docs)
+  }
+  return cursor
+}
+
+/**
+ * Creates a mock SpoorTrackingModule instance with stubbed content + mongodb collaborators.
+ * `config` lets each test seed the counter/content collection responses.
+ */
+function createMockInstance (config = {}) {
+  const {
+    counterDoc = null, // result of counters.findOne
+    incResult = { seq: 1 }, // result of counters.findOneAndUpdate
+    maxBlock = [] // docs returned for the findMaxTrackingId lookup
+  } = config
+
+  const countersMock = {
+    findOne: mock.fn(async () => counterDoc),
+    updateOne: mock.fn(async () => ({})),
+    findOneAndUpdate: mock.fn(async () => incResult)
+  }
+  const contentColMock = {
+    find: mock.fn(() => makeCursor(maxBlock)),
+    updateOne: mock.fn(async () => ({}))
+  }
+
   const contentMock = {
-    find: mock.fn(async () => []),
-    update: mock.fn(async () => ({})),
+    collectionName: 'content',
+    counterCollectionName: 'contentcounters',
     preInsertHook: { tap: mock.fn() }
   }
-  const authMock = {
-    secureRoute: mock.fn()
+  const mongodbMock = {
+    getCollection: mock.fn(name => name === 'contentcounters' ? countersMock : contentColMock)
   }
-  const serverMock = {
-    api: {
-      createChildRouter: mock.fn(() => ({
-        addRoute: mock.fn()
-      }))
-    }
-  }
-  const appMock = {
-    waitForModule: mock.fn(async (...names) => {
-      const map = { auth: authMock, content: contentMock, server: serverMock }
-      if (names.length === 1) return map[names[0]]
-      return names.map(n => map[n])
-    })
-  }
-  const logMock = mock.fn()
 
   const instance = Object.create(SpoorTrackingModule.prototype)
-  instance.app = appMock
-  instance.log = logMock
-  instance._contentMock = contentMock
-  instance._authMock = authMock
-  instance._serverMock = serverMock
-  instance._appMock = appMock
-
-  Object.assign(instance, overrides)
+  instance.content = contentMock
+  instance.mongodb = mongodbMock
+  instance.log = mock.fn()
+  instance._counters = countersMock
+  instance._contentCol = contentColMock
   return instance
 }
 
@@ -52,160 +63,121 @@ describe('SpoorTrackingModule', () => {
 
     beforeEach(() => {
       instance = createMockInstance()
+      instance.allocateTrackingIds = mock.fn(async () => [42])
     })
 
     it('should skip non-block types', async () => {
-      const data = { _type: 'component', _courseId: 'course1' }
+      const data = { _type: 'component', _courseId: COURSE_ID }
       await instance.insertTrackingId(data)
-      assert.equal(instance._contentMock.find.mock.callCount(), 0)
+      assert.equal(instance.allocateTrackingIds.mock.callCount(), 0)
       assert.equal(data._trackingId, undefined)
     })
 
-    it('should skip if _trackingId is already an integer', async () => {
-      const data = { _type: 'block', _courseId: 'course1', _trackingId: 5 }
-      await instance.insertTrackingId(data)
-      assert.equal(instance._contentMock.find.mock.callCount(), 0)
+    it('should skip multilang sync inserts (replicas reuse the source id)', async () => {
+      const data = { _type: 'block', _courseId: COURSE_ID, _trackingId: 5 }
+      await instance.insertTrackingId(data, { _multilangSync: true })
+      assert.equal(instance.allocateTrackingIds.mock.callCount(), 0)
       assert.equal(data._trackingId, 5)
     })
 
-    it('should skip if _trackingId is 0 (a valid integer)', async () => {
-      const data = { _type: 'block', _courseId: 'course1', _trackingId: 0 }
+    it('should allocate a tracking id for a block', async () => {
+      const data = { _type: 'block', _courseId: COURSE_ID }
       await instance.insertTrackingId(data)
-      assert.equal(instance._contentMock.find.mock.callCount(), 0)
-      assert.equal(data._trackingId, 0)
+      assert.equal(instance.allocateTrackingIds.mock.callCount(), 1)
+      assert.deepEqual(instance.allocateTrackingIds.mock.calls[0].arguments, [COURSE_ID, 1])
+      assert.equal(data._trackingId, 42)
     })
 
-    it('should assign _trackingId as max + 1 when blocks exist', async () => {
-      instance._contentMock.find.mock.mockImplementation(async () => [{ _trackingId: 10 }])
-      const data = { _type: 'block', _courseId: 'course1' }
+    it('should overwrite an incoming id on a non-sync block insert (e.g. a clone payload)', async () => {
+      const data = { _type: 'block', _courseId: COURSE_ID, _trackingId: 99 }
       await instance.insertTrackingId(data)
-      assert.equal(data._trackingId, 11)
+      assert.equal(data._trackingId, 42)
+    })
+  })
+
+  describe('allocateTrackingIds', () => {
+    it('should return an empty array for count < 1', async () => {
+      const instance = createMockInstance()
+      assert.deepEqual(await instance.allocateTrackingIds(COURSE_ID, 0), [])
+      assert.equal(instance._counters.findOneAndUpdate.mock.callCount(), 0)
     })
 
-    it('should assign _trackingId 1 when existing block has _trackingId 0', async () => {
-      instance._contentMock.find.mock.mockImplementation(async () => [{ _trackingId: 0 }])
-      const data = { _type: 'block', _courseId: 'course1' }
-      await instance.insertTrackingId(data)
-      assert.equal(data._trackingId, 1)
+    it('should seed from the existing max then increment when no counter exists', async () => {
+      const instance = createMockInstance({
+        counterDoc: null,
+        maxBlock: [{ _trackingId: 10 }],
+        incResult: { seq: 11 }
+      })
+      const ids = await instance.allocateTrackingIds(COURSE_ID, 1)
+      const seedCall = instance._counters.updateOne.mock.calls[0]
+      assert.deepEqual(seedCall.arguments[1], { $setOnInsert: { seq: 10 } })
+      assert.deepEqual(seedCall.arguments[2], { upsert: true })
+      assert.deepEqual(ids, [11])
     })
 
-    it('should call content.find with correct query and options', async () => {
-      instance._contentMock.find.mock.mockImplementation(async () => [{ _trackingId: 3 }])
-      const data = { _type: 'block', _courseId: 'courseABC' }
-      await instance.insertTrackingId(data)
-      const call = instance._contentMock.find.mock.calls[0]
-      assert.deepEqual(call.arguments[0], { _courseId: 'courseABC' })
-      assert.deepEqual(call.arguments[1], {})
-      assert.deepEqual(call.arguments[2], { limit: 1, sort: [['_trackingId', -1]] })
+    it('should not seed when a counter already exists', async () => {
+      const instance = createMockInstance({
+        counterDoc: { seq: 5 },
+        incResult: { seq: 8 }
+      })
+      const ids = await instance.allocateTrackingIds(COURSE_ID, 3)
+      assert.equal(instance._counters.updateOne.mock.callCount(), 0)
+      assert.deepEqual(ids, [6, 7, 8])
     })
 
-    it('should not skip when _trackingId is a non-integer number', async () => {
-      instance._contentMock.find.mock.mockImplementation(async () => [{ _trackingId: 5 }])
-      const data = { _type: 'block', _courseId: 'course1', _trackingId: 1.5 }
-      await instance.insertTrackingId(data)
-      assert.equal(data._trackingId, 6)
+    it('should reserve a contiguous range and $inc by count', async () => {
+      const instance = createMockInstance({
+        counterDoc: { seq: 0 },
+        incResult: { seq: 4 }
+      })
+      const ids = await instance.allocateTrackingIds(COURSE_ID, 4)
+      const incCall = instance._counters.findOneAndUpdate.mock.calls[0]
+      assert.deepEqual(incCall.arguments[1], { $inc: { seq: 4 } })
+      assert.deepEqual(incCall.arguments[2], { returnDocument: 'after' })
+      assert.deepEqual(ids, [1, 2, 3, 4])
+    })
+  })
+
+  describe('findMaxTrackingId', () => {
+    it('should return 0 when the course has no blocks', async () => {
+      const instance = createMockInstance({ maxBlock: [] })
+      assert.equal(await instance.findMaxTrackingId(COURSE_ID), 0)
     })
 
-    it('should not skip when _trackingId is a string', async () => {
-      instance._contentMock.find.mock.mockImplementation(async () => [{ _trackingId: 2 }])
-      const data = { _type: 'block', _courseId: 'course1', _trackingId: '5' }
-      await instance.insertTrackingId(data)
-      assert.equal(data._trackingId, 3)
-    })
-
-    it('should use nullish coalescing so undefined _trackingId defaults to 1', async () => {
-      instance._contentMock.find.mock.mockImplementation(async () => [{ _trackingId: undefined }])
-      const data = { _type: 'block', _courseId: 'course1' }
-      await instance.insertTrackingId(data)
-      assert.equal(data._trackingId, 1)
-    })
-
-    it('should handle null _trackingId in result using nullish coalescing', async () => {
-      instance._contentMock.find.mock.mockImplementation(async () => [{ _trackingId: null }])
-      const data = { _type: 'block', _courseId: 'course1' }
-      await instance.insertTrackingId(data)
-      assert.equal(data._trackingId, 1)
-    })
-
-    it('should handle empty find result gracefully', async () => {
-      instance._contentMock.find.mock.mockImplementation(async () => [])
-      const data = { _type: 'block', _courseId: 'emptyCourse' }
-      await instance.insertTrackingId(data)
-      assert.equal(data._trackingId, 1)
+    it('should return the highest tracking id', async () => {
+      const instance = createMockInstance({ maxBlock: [{ _trackingId: 17 }] })
+      assert.equal(await instance.findMaxTrackingId(COURSE_ID), 17)
     })
   })
 
   describe('resetCourseTrackingIds', () => {
-    let instance
+    it('should renumber blocks 1..n and realign the counter', async () => {
+      const instance = createMockInstance()
+      instance._contentCol.find.mock.mockImplementation(() => makeCursor([{ _id: 'b1' }, { _id: 'b2' }, { _id: 'b3' }]))
+      await instance.resetCourseTrackingIds(COURSE_ID)
 
-    beforeEach(() => {
-      instance = createMockInstance()
-    })
-
-    it('should reassign sequential _trackingId values starting from 1', async () => {
-      const blocks = [
-        { _id: 'b1', _trackingId: 5 },
-        { _id: 'b2', _trackingId: 12 },
-        { _id: 'b3', _trackingId: 20 }
-      ]
-      instance._contentMock.find.mock.mockImplementation(async () => blocks)
-      await instance.resetCourseTrackingIds('course1')
-
-      const updateCalls = instance._contentMock.update.mock.calls
-      assert.equal(updateCalls.length, 3)
-      assert.deepEqual(updateCalls[0].arguments, [{ _id: 'b1' }, { _trackingId: 1 }, { schemaName: 'block' }])
-      assert.deepEqual(updateCalls[1].arguments, [{ _id: 'b2' }, { _trackingId: 2 }, { schemaName: 'block' }])
-      assert.deepEqual(updateCalls[2].arguments, [{ _id: 'b3' }, { _trackingId: 3 }, { schemaName: 'block' }])
-    })
-
-    it('should query for blocks sorted by _trackingId ascending', async () => {
-      instance._contentMock.find.mock.mockImplementation(async () => [])
-      await instance.resetCourseTrackingIds('courseXYZ')
-
-      const call = instance._contentMock.find.mock.calls[0]
-      assert.deepEqual(call.arguments[0], { _type: 'block', _courseId: 'courseXYZ' })
-      assert.deepEqual(call.arguments[1], {})
-      assert.deepEqual(call.arguments[2], { sort: [['_trackingId', 1]] })
-    })
-
-    it('should do nothing when no blocks are found', async () => {
-      instance._contentMock.find.mock.mockImplementation(async () => [])
-      await instance.resetCourseTrackingIds('emptyCourse')
-      assert.equal(instance._contentMock.update.mock.callCount(), 0)
-    })
-
-    it('should log a debug message after resetting', async () => {
-      instance._contentMock.find.mock.mockImplementation(async () => [])
-      await instance.resetCourseTrackingIds('course1')
+      const updates = instance._contentCol.updateOne.mock.calls
+      assert.equal(updates.length, 3)
+      assert.deepEqual(updates[0].arguments, [{ _id: 'b1' }, { $set: { _trackingId: 1 } }])
+      assert.deepEqual(updates[1].arguments, [{ _id: 'b2' }, { $set: { _trackingId: 2 } }])
+      assert.deepEqual(updates[2].arguments, [{ _id: 'b3' }, { $set: { _trackingId: 3 } }])
+      const counterUpdate = instance._counters.updateOne.mock.calls[0]
+      assert.deepEqual(counterUpdate.arguments[1], { $set: { seq: 3 } })
       assert.equal(instance.log.mock.callCount(), 1)
-      assert.deepEqual(instance.log.mock.calls[0].arguments, ['debug', 'RESET', 'course1'])
     })
 
-    it('should handle a single block', async () => {
-      const blocks = [{ _id: 'b1', _trackingId: 99 }]
-      instance._contentMock.find.mock.mockImplementation(async () => blocks)
-      await instance.resetCourseTrackingIds('course1')
-
-      const updateCalls = instance._contentMock.update.mock.calls
-      assert.equal(updateCalls.length, 1)
-      assert.deepEqual(updateCalls[0].arguments, [{ _id: 'b1' }, { _trackingId: 1 }, { schemaName: 'block' }])
+    it('should do nothing to blocks when none are found', async () => {
+      const instance = createMockInstance()
+      instance._contentCol.find.mock.mockImplementation(() => makeCursor([]))
+      await instance.resetCourseTrackingIds(COURSE_ID)
+      assert.equal(instance._contentCol.updateOne.mock.callCount(), 0)
+      assert.deepEqual(instance._counters.updateOne.mock.calls[0].arguments[1], { $set: { seq: 0 } })
     })
 
-    it('should propagate errors from content.find', async () => {
-      instance._contentMock.find.mock.mockImplementation(async () => { throw new Error('db error') })
-      await assert.rejects(
-        () => instance.resetCourseTrackingIds('course1'),
-        { message: 'db error' }
-      )
-    })
-
-    it('should propagate errors from content.update', async () => {
-      instance._contentMock.find.mock.mockImplementation(async () => [{ _id: 'b1', _trackingId: 1 }])
-      instance._contentMock.update.mock.mockImplementation(async () => { throw new Error('update failed') })
-      await assert.rejects(
-        () => instance.resetCourseTrackingIds('course1'),
-        { message: 'update failed' }
-      )
+    it('should propagate errors', async () => {
+      const instance = createMockInstance()
+      instance._contentCol.find.mock.mockImplementation(() => { throw new Error('db error') })
+      await assert.rejects(() => instance.resetCourseTrackingIds(COURSE_ID), { message: 'db error' })
     })
   })
 
@@ -214,54 +186,35 @@ describe('SpoorTrackingModule', () => {
 
     beforeEach(() => {
       instance = createMockInstance()
+      instance.resetCourseTrackingIds = mock.fn(async () => {})
     })
 
-    it('should call resetCourseTrackingIds with the courseId from params', async () => {
-      instance._contentMock.find.mock.mockImplementation(async () => [])
-      const req = { params: { _courseId: 'course123' } }
+    it('should reset using the courseId param and send 204', async () => {
+      const req = { params: { _courseId: COURSE_ID } }
       const res = { sendStatus: mock.fn() }
       const next = mock.fn()
-
       await instance.resetTrackingHandler(req, res, next)
-
-      const findCall = instance._contentMock.find.mock.calls[0]
-      assert.deepEqual(findCall.arguments[0], { _type: 'block', _courseId: 'course123' })
-    })
-
-    it('should send 204 on success', async () => {
-      instance._contentMock.find.mock.mockImplementation(async () => [])
-      const req = { params: { _courseId: 'course1' } }
-      const res = { sendStatus: mock.fn() }
-      const next = mock.fn()
-
-      await instance.resetTrackingHandler(req, res, next)
-
-      assert.equal(res.sendStatus.mock.callCount(), 1)
+      assert.deepEqual(instance.resetCourseTrackingIds.mock.calls[0].arguments, [COURSE_ID])
       assert.deepEqual(res.sendStatus.mock.calls[0].arguments, [204])
       assert.equal(next.mock.callCount(), 0)
     })
 
-    it('should call next with error on failure', async () => {
-      instance._contentMock.find.mock.mockImplementation(async () => { throw new Error('fail') })
-      const req = { params: { _courseId: 'course1' } }
+    it('should call next with the error on failure', async () => {
+      instance.resetCourseTrackingIds = mock.fn(async () => { throw new Error('fail') })
+      const req = { params: { _courseId: COURSE_ID } }
       const res = { sendStatus: mock.fn() }
       const next = mock.fn()
-
       await instance.resetTrackingHandler(req, res, next)
-
-      assert.equal(next.mock.callCount(), 1)
       assert.equal(next.mock.calls[0].arguments[0].message, 'fail')
       assert.equal(res.sendStatus.mock.callCount(), 0)
     })
   })
 
   describe('class structure', () => {
-    it('should export a class', () => {
+    it('should export a class with the expected methods', () => {
       assert.equal(typeof SpoorTrackingModule, 'function')
-      assert.equal(typeof SpoorTrackingModule.prototype.init, 'function')
-      assert.equal(typeof SpoorTrackingModule.prototype.insertTrackingId, 'function')
-      assert.equal(typeof SpoorTrackingModule.prototype.resetCourseTrackingIds, 'function')
-      assert.equal(typeof SpoorTrackingModule.prototype.resetTrackingHandler, 'function')
+      ;['init', 'insertTrackingId', 'allocateTrackingIds', 'findMaxTrackingId', 'resetCourseTrackingIds', 'resetTrackingHandler']
+        .forEach(m => assert.equal(typeof SpoorTrackingModule.prototype[m], 'function'))
     })
   })
 })


### PR DESCRIPTION
### Fixes #36

### Fix
- Replace the read-max-then-increment in `insertTrackingId` with allocation from a per-course **atomic counter** (`findOneAndUpdate` `$inc`), seeded once from the existing max. This bypasses the content `DataCache` (which is TTL-only with no write-invalidation), so rapid/sequential block inserts can no longer be handed duplicate `_trackingId`s — the root cause of #36 / #201.
- All tracking-ID logic now lives in this module: the hook also fires once per payload during a bulk clone, so cloned blocks allocate here too. Multilang language replicas (flagged `_multilangSync`) intentionally reuse the source ID and are skipped.
- Counter is stored in content's existing `contentcounters` collection, so course deletion cleans it up via content's existing sweep — no new collection or index.
- `resetCourseTrackingIds` now reads/writes Mongo directly (cache-safe) and realigns the counter; it remains the canonical renumber routine.
- Added `adapt-authoring-mongodb` peer dependency.

### Breaking
- None.

### Testing
- `lib/SpoorTrackingModule.spec.js` rewritten: covers allocation (seed + `$inc`, contiguous ranges), multilang skip, clone-payload overwrite, reset + counter realignment, and the handler. 16/16 pass; `standard` clean.

> ⚠️ Release ordering: this must release **before or with** the matching `adapt-authoring-content` PR. New spoortracking is compatible with old content, but new content (clone no longer allocates) regresses with old spoortracking.