### PR TITLE
New: Block build when tracked blocks lack tracking IDs (fixes #38)

### DIFF
--- a/errors/errors.json
+++ b/errors/errors.json
@@ -1,0 +1,9 @@
+{
+  "MISSING_TRACKING_IDS": {
+    "data": {
+      "blocks": "The blocks missing a tracking ID"
+    },
+    "description": "Course cannot be built: SCORM tracking is enabled but one or more blocks have no tracking ID",
+    "statusCode": 400
+  }
+}

--- a/lib/SpoorTrackingModule.js
+++ b/lib/SpoorTrackingModule.js
@@ -18,6 +18,12 @@ class SpoorTrackingModule extends AbstractModule {
     // bulk clone, so this is the single place tracking IDs are assigned.
     content.preInsertHook.tap(this.insertTrackingId.bind(this))
 
+    // refuse a build when tracking is enabled but blocks are missing tracking IDs. adaptframework
+    // depends on content (not vice-versa), so tap its hook once available rather than awaiting here.
+    this.app.waitForModule('adaptframework').then(framework => {
+      framework.preBuildHook.tap(this.enforceTrackingIds.bind(this))
+    })
+
     const config = await loadRouteConfig(this.rootDir, this)
     const router = server.api.createChildRouter(config.root)
     registerRoutes(router, config.routes, auth)
@@ -46,6 +52,32 @@ class SpoorTrackingModule extends AbstractModule {
     }
     const [trackingId] = await this.allocateTrackingIds(data._courseId, 1)
     data._trackingId = trackingId
+  }
+
+  /**
+   * preBuildHook observer: when SCORM tracking is enabled for the course
+   * (`config._spoor._isEnabled === true`), refuses the build if any block is missing a numeric
+   * `_trackingId`. Blocks created in the tool always get one on insert, so a missing id means
+   * imported or legacy content — `resetCourseTrackingIds` renumbers the whole course to fix it.
+   * @param {AdaptFrameworkBuild} build The build being run
+   * @return {Promise}
+   */
+  async enforceTrackingIds (build) {
+    const _courseId = parseObjectId(build.courseId)
+    const collection = this.mongodb.getCollection(this.content.collectionName)
+    const config = await collection.findOne({ _type: 'config', _courseId }, { projection: { _spoor: 1 } })
+    if (config?._spoor?._isEnabled !== true) {
+      return
+    }
+    const untracked = await collection
+      .find({ _type: 'block', _courseId, _trackingId: { $not: { $type: 'number' } } }, { projection: { title: 1 } })
+      .toArray()
+    if (!untracked.length) {
+      return
+    }
+    throw this.app.errors.MISSING_TRACKING_IDS.setData({
+      blocks: untracked.map(b => ({ _id: b._id.toString(), title: b.title }))
+    })
   }
 
   /**

--- a/tests/SpoorTrackingModule.spec.js
+++ b/tests/SpoorTrackingModule.spec.js
@@ -26,7 +26,8 @@ function createMockInstance (config = {}) {
   const {
     counterDoc = null, // result of counters.findOne
     incResult = { seq: 1 }, // result of counters.findOneAndUpdate
-    maxBlock = [] // docs returned for the findMaxTrackingId lookup
+    maxBlock = [], // docs returned for the findMaxTrackingId lookup
+    configDoc = null // result of content.findOne for the course config
   } = config
 
   const countersMock = {
@@ -36,6 +37,7 @@ function createMockInstance (config = {}) {
   }
   const contentColMock = {
     find: mock.fn(() => makeCursor(maxBlock)),
+    findOne: mock.fn(async () => configDoc),
     updateOne: mock.fn(async () => ({}))
   }
 
@@ -52,6 +54,13 @@ function createMockInstance (config = {}) {
   instance.content = contentMock
   instance.mongodb = mongodbMock
   instance.log = mock.fn()
+  instance.app = {
+    errors: {
+      MISSING_TRACKING_IDS: {
+        setData: data => Object.assign(new Error('MISSING_TRACKING_IDS'), { code: 'MISSING_TRACKING_IDS', data })
+      }
+    }
+  }
   instance._counters = countersMock
   instance._contentCol = contentColMock
   return instance
@@ -210,10 +219,52 @@ describe('SpoorTrackingModule', () => {
     })
   })
 
+  describe('enforceTrackingIds', () => {
+    const build = { courseId: COURSE_ID }
+
+    it('should do nothing when tracking is not enabled', async () => {
+      const instance = createMockInstance({ configDoc: { _spoor: { _isEnabled: false } } })
+      // even if blocks were untracked, the find should never run
+      instance._contentCol.find.mock.mockImplementation(() => makeCursor([{ _id: 'b1' }]))
+      await instance.enforceTrackingIds(build)
+      assert.equal(instance._contentCol.find.mock.callCount(), 0)
+    })
+
+    it('should do nothing when there is no config', async () => {
+      const instance = createMockInstance({ configDoc: null })
+      await instance.enforceTrackingIds(build)
+      assert.equal(instance._contentCol.find.mock.callCount(), 0)
+    })
+
+    it('should pass when tracking is enabled and every block has a tracking id', async () => {
+      const instance = createMockInstance({ configDoc: { _spoor: { _isEnabled: true } } })
+      instance._contentCol.find.mock.mockImplementation(() => makeCursor([]))
+      await instance.enforceTrackingIds(build) // resolves without throwing
+      const query = instance._contentCol.find.mock.calls[0].arguments[0]
+      assert.deepEqual(query._trackingId, { $not: { $type: 'number' } })
+    })
+
+    it('should throw MISSING_TRACKING_IDS listing the untracked blocks', async () => {
+      const instance = createMockInstance({ configDoc: { _spoor: { _isEnabled: true } } })
+      instance._contentCol.find.mock.mockImplementation(() => makeCursor([
+        { _id: { toString: () => 'b1' }, title: 'Intro' },
+        { _id: { toString: () => 'b2' }, title: 'Outro' }
+      ]))
+      await assert.rejects(() => instance.enforceTrackingIds(build), err => {
+        assert.equal(err.code, 'MISSING_TRACKING_IDS')
+        assert.deepEqual(err.data.blocks, [
+          { _id: 'b1', title: 'Intro' },
+          { _id: 'b2', title: 'Outro' }
+        ])
+        return true
+      })
+    })
+  })
+
   describe('class structure', () => {
     it('should export a class with the expected methods', () => {
       assert.equal(typeof SpoorTrackingModule, 'function')
-      ;['init', 'insertTrackingId', 'allocateTrackingIds', 'findMaxTrackingId', 'resetCourseTrackingIds', 'resetTrackingHandler']
+      ;['init', 'insertTrackingId', 'enforceTrackingIds', 'allocateTrackingIds', 'findMaxTrackingId', 'resetCourseTrackingIds', 'resetTrackingHandler']
         .forEach(m => assert.equal(typeof SpoorTrackingModule.prototype[m], 'function'))
     })
   })


### PR DESCRIPTION
### Fixes #38

### New
- Refuse a course build (preview, publish and export) when SCORM tracking is enabled (`config._spoor._isEnabled === true`) and any block is missing a numeric `_trackingId`. Blocks created in the tool always get one on insert, so a missing id means imported or legacy content — `resetCourseTrackingIds` remediates.
- Enforced server-side by tapping the existing `adaptframework.preBuildHook`, non-blocking (adaptframework depends on this module, not vice-versa). Adds a new `MISSING_TRACKING_IDS` (400) error listing the offending blocks.

### Testing
- New unit tests for `enforceTrackingIds`: skips when tracking disabled / no config, passes when all blocks tracked, throws listing untracked blocks.
- Full suite: 20 tests pass; `standard` clean.